### PR TITLE
Fixed docker-compose file to work around incompatibilities with latest versions

### DIFF
--- a/Ubuntu/docker-compose.yml
+++ b/Ubuntu/docker-compose.yml
@@ -2,17 +2,17 @@ version: "2"
 services:
   influxdb:
     container_name: influxdb
-    image: influxdb:latest
+    image: influxdb:1.8.3
     ports:
-      - "8083:8083"
       - "8086:8086"
+      - "8083:8083"
     volumes:
       - ./vols/:/var/lib/influxdb
     restart: always
 
   grafana:
     container_name: grafana
-    image: grafana/grafana:latest
+    image: grafana/grafana:6.3.7
     ports:
       - "3000:3000"
     links:
@@ -21,7 +21,7 @@ services:
 
   telegraf:
     container_name: telegraf
-    image: telegraf:latest 
+    image: telegraf:1.16.1
     ports:
       - "57000:57000"   
     links:


### PR DESCRIPTION
Adding in versions for telegraf, influxdb and grafana as the latest docker images are not compatible with the demo in the CBT nuggets skill for MDT. Both influxDB and grafana threw 401 errors as the new versions have different requirements for authentication. Doing it this way saves you having to re-record the videos for these nuggets every few months :)